### PR TITLE
Update PipeModeDataset to open FIFO immediately on Iterator creation,…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],
-    install_requires=['tensorflow>=1.9'],
+    install_requires=['tensorflow>=1.9,<1.10'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
                  'sagemaker', 'docker', 'boto3']

--- a/src/pipemode_op/RecordReader/RecordReader.cpp
+++ b/src/pipemode_op/RecordReader/RecordReader.cpp
@@ -44,7 +44,13 @@ RecordReader::RecordReader(const std::string& file_path, const std::size_t read_
     fd_(UNSET_FILE_DESCRIPTOR),
     file_path_(file_path),
     read_size_(read_size),
-    file_creation_timeout_(file_creation_timeout)  {}
+    file_creation_timeout_(file_creation_timeout)  {
+        WaitForFile();
+        fd_ = open(file_path_.c_str(), O_RDONLY);
+        if (-1 == fd_) {
+            throw std::system_error(errno, std::system_category());
+        }
+    }
 
 RecordReader::~RecordReader() {
     if (fd_ >= 0) {
@@ -53,13 +59,6 @@ RecordReader::~RecordReader() {
 }
 
 std::size_t RecordReader::Read(void* dest, std::size_t nbytes) {
-    if (fd_ == UNSET_FILE_DESCRIPTOR) {
-        WaitForFile();
-        fd_ = open(file_path_.c_str(), O_RDONLY);
-        if (-1 == fd_) {
-            throw std::system_error(errno, std::system_category());
-        }
-    }
     std::size_t bytes_read = 0;
     while (nbytes) {
         ssize_t read_amount = read(fd_, dest + bytes_read, std::min(nbytes, read_size_));

--- a/src/pipemode_op/test/testRecordReader/TestRecordReader.cpp
+++ b/src/pipemode_op/test/testRecordReader/TestRecordReader.cpp
@@ -96,9 +96,8 @@ TEST_F(RecordReaderTest, WaitForFile) {
 TEST_F(RecordReaderTest, WaitForFileFails) {
     std::string channelDirectory = CreateTemporaryDirectory();
     auto timeout = std::chrono::seconds(2);
-    std::unique_ptr<TestReader> reader = std::unique_ptr<TestReader>(
-        new TestReader(channelDirectory + "/missing.file", 200, timeout));
     EXPECT_THROW({
-        reader->WrapWaitForFile();},
+        std::unique_ptr<TestReader> reader = std::unique_ptr<TestReader>(
+        new TestReader(channelDirectory + "/missing.file", 200, timeout));},
         std::runtime_error);
 }

--- a/test/integ/scripts/estimator_script.py
+++ b/test/integ/scripts/estimator_script.py
@@ -78,3 +78,23 @@ estimator.train(input_fn=input_fn)
 
 # Confirm that we have read the correct number of pipes
 assert os.path.exists('/opt/ml/input/data/{}_{}'.format(config.channel, config.epochs))
+
+
+# Test that we can create a new PipeModeDataset after training has run
+ds = PipeModeDataset(config.channel)
+
+with tf.Session() as sess:
+    it = ds.make_one_shot_iterator()
+    next = it.get_next()
+    sess.run(next)
+
+# Test that we can create a PipeModeDataset, discard it, and read from a new one
+ds = PipeModeDataset(config.channel)
+with tf.Session() as sess:
+    it = ds.make_one_shot_iterator()
+    next = it.get_next()
+ds = PipeModeDataset(config.channel)
+with tf.Session() as sess:
+    it = ds.make_one_shot_iterator()
+    next = it.get_next()
+    sess.run(next)


### PR DESCRIPTION
Update PipeModeDataset to open FIFO immediately on Iterator creation


** Description ** Update PipeModeDataset to open FIFO immediately on Iterator creation, rather than on Iterator GetNext. This fixes a bug where creating an Iterator, but then discarding it, and recreating a second iterator and reading from that would hang.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
