### PR TITLE
add new line after hyperlink

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 CHANGELOG
 =========
 
+1.12.0.1.0.0.post1
+==================
+
+* doc-fix: Fix README for PyPI
+
+1.12.0.1.0.0
+============
+
+* enhancement: Support for TensorFlow 1.12
+
 1.11.0.1.0.0
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,7 @@ We're here to help. Have a question? Please open a `GitHub issue`__, we'd love t
 .. _X: https://github.com/aws/sagemaker-tensorflow-extensions/issues/new
 
 __ X_
+
 License
 ~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='1.12.0.1.0.0',
+    version='1.12.0.1.0.0.post1',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},


### PR DESCRIPTION
Fix readme on PyPi: https://pypi.org/project/sagemaker-tensorflow/1.12.0.1.0.0/

Missing newline.

https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup

Twine provides the ability to check if your readme will render properly on PyPI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
