### PR TITLE
fix: remove py35 whl file becasue codebuild does not install py35

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -23,7 +23,7 @@ phases:
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.6 python3.5 python2.7"
+        PYTHON_VERSIONS="python3.6 python2.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install wheel tensorflow==1.14 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
@@ -34,8 +34,7 @@ phases:
 
 artifacts:
   files:
-    - dist/sagemaker_tensorflow-cp27-*.whl
-    - dist/sagemaker_tensorflow-cp35-*.whl
-    - dist/sagemaker_tensorflow-cp36-*.whl
+    - dist/sagemaker_tensorflow-*-cp27-*.whl
+    - dist/sagemaker_tensorflow-*-cp36-*.whl
   name: ARTIFACT_1
   discard-paths: yes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the code build cannot generate sagemaker_tensorflow-*-cp35-*.whl because python3.5 is not installed in codebuild image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
