### PR TITLE
fix: remove py35 from buildspec-deploy

### DIFF
--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -3,9 +3,8 @@ version: 0.2
 phases:
   build:
     commands:
-      - PACKAGE_FILE_27="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-cp27-*.whl"
-      - PACKAGE_FILE_35="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-cp35-*.whl"
-      - PACKAGE_FILE_36="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorlfow-cp36-*.whl"
+      - PACKAGE_FILE_27="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp27-*.whl"
+      - PACKAGE_FILE_36="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorlfow-*-cp36-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
@@ -19,10 +18,8 @@ phases:
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_27
-      - gpg --pinentry-mode lookpack --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_35
       - gpg --pinentry-mode lookpack --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
 
       # publish to pypi
       - python27 -m twine upload $PACKAGE_FILE_27 --sign -u $PYPI_USER -p $PYPI_PASSWORD
-      - python35 -m twine upload $PACKAGE_FILE_35 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python36 -m twine upload $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to #51 , remove py35 whl from deploy buildspec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
