### PR TITLE
fix: skipping existing files on pypi

### DIFF
--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -17,8 +17,8 @@ phases:
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_27
-      - gpg --pinentry-mode lookpack --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
+      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
 
       # publish to pypi
-      - python27 -m twine upload $PACKAGE_FILE_27 --sign -u $PYPI_USER -p $PYPI_PASSWORD
-      - python36 -m twine upload $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_27 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- skip existing files on pypi. py36 version was released through teamcity before, so `twine upload` will fail without `--skip-existing`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
