### PR TITLE
Add parameter benchmark_records_interval to emit benchmark metrics on a configurable interval

### DIFF
--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
         cache_from=[tag],
         buildargs={'sagemaker_tensorflow': sdist_path,
                    'device': args.device,
-                   'python': 'python' if python_version == 2 else 'python3',
+                   'python': '/usr/bin/python3',
                    'tensorflow_version': TF_VERSION,
                    'script': 'test/integ/scripts/estimator_script.py'})
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ class CMakeBuild(build_ext):
             env.get('CXXFLAGS', ''),
             self.distribution.get_version())
 
-        env['CXX'] = 'g++-5'
+        env['CXX'] = 'g++'
         env['PYTHON_EXECUTABLE'] = sys.executable
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.0.0.1.0.0',
+    version='2.0.0.1.1.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -88,6 +88,7 @@ class PipeModeDatasetOp : public DatasetOpKernel {
         std::string channel_directory;
         std::string channel;
         bool benchmark;
+        std::uint64_t benchmark_records_interval;
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::string>(ctx, "record_format",
                                                         &record_format));
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::string>(ctx, "state_directory",
@@ -100,27 +101,32 @@ class PipeModeDatasetOp : public DatasetOpKernel {
             tensorflow::errors::InvalidArgument("Invalid record format: " + record_format));
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<bool>(ctx, "benchmark",
                                                         &benchmark));
-        *output = new Dataset(ctx, record_format, state_directory, channel_directory, channel, benchmark);
+        OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::uint64_t>(ctx, "benchmark_records_interval",
+                                                        &benchmark_records_interval));
+        *output = new Dataset(ctx, record_format, state_directory, channel_directory, channel, benchmark,
+                              benchmark_records_interval);
     }
 
  private:
     class Dataset : public DatasetBase {
      public:
         explicit Dataset(OpKernelContext* ctx, const std::string& record_format, const std::string& state_directory,
-            const std::string& channel_directory, const std::string& channel, bool benchmark):
+            const std::string& channel_directory, const std::string& channel, bool benchmark,
+            std::uint64_t benchmark_records_interval):
             DatasetBase(DatasetContext(ctx)),
             record_format_(record_format),
             channel_directory_(channel_directory),
             pipe_state_manager_(state_directory, channel),
             channel_(channel),
-            benchmark_(benchmark) {}
+            benchmark_(benchmark),
+            benchmark_records_interval_(benchmark_records_interval) {}
 
         std::unique_ptr<IteratorBase> MakeIteratorInternal(const std::string& prefix) const override {
             auto new_prefix = prefix + "::PipeMode-" + channel_ + "-"
                 + std::to_string(pipe_state_manager_.GetPipeIndex());
             auto ptr = std::unique_ptr<IteratorBase>(
                 new Iterator({this, new_prefix}, record_format_, channel_directory_, channel_, benchmark_,
-                    pipe_state_manager_.GetPipeIndex()));
+                    pipe_state_manager_.GetPipeIndex(), benchmark_records_interval_));
             pipe_state_manager_.IncrementPipeIndex();
             return ptr;
         }
@@ -151,14 +157,15 @@ class PipeModeDatasetOp : public DatasetOpKernel {
         std::string channel_;
         PipeStateManager pipe_state_manager_;
         bool benchmark_;
+        std::uint64_t benchmark_records_interval_;
 
         class Iterator : public DatasetIterator<Dataset> {
          public:
             explicit Iterator(const Params& params, const std::string& record_format,
                 const std::string& channel_directory, const std::string& channel, const bool benchmark,
-                const uint32_t pipe_index)
+                const uint32_t pipe_index, const uint64_t benchmark_records_interval)
                 : DatasetIterator<Dataset>(params), read_time_(0), read_bytes_(0),
-                    benchmark_(benchmark) {
+                    benchmark_(benchmark), benchmark_records_interval_(benchmark_records_interval) {
                     std::string pipe_path = BuildPipeName(channel_directory, channel, pipe_index);
                     if (record_format == "RecordIO") {
                         record_reader_ = std::unique_ptr<RecordReader>(new RecordIOReader(pipe_path));
@@ -184,8 +191,17 @@ class PipeModeDatasetOp : public DatasetOpKernel {
                         *end_of_sequence = true;
                     }
                     auto end = std::chrono::high_resolution_clock::now();
-                    read_time_ = read_time_ + std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+                    auto delta_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+                    read_time_ += delta_ns;
                     read_bytes_ += storage->size();
+                    records_read_++;
+                    if (benchmark_records_interval_ != 0 && (records_read_ % benchmark_records_interval_ == 0)) {
+                        std::cout << "PipeModeDatasetOp::Dataset::Iterator records: " << records_read_  << std::endl;
+                        std::cout << "PipeModeDatasetOp::Dataset::Iterator records read_time_ns: " << delta_ns.count()
+                            << std::endl;
+                        std::cout << "PipeModeDatasetOp::Dataset::Iterator records read_bytes: " << storage->size()
+                            << std::endl;
+                    }
                 } catch(std::runtime_error& err) {
                     return Status(tensorflow::error::INTERNAL, err.what());
                 }
@@ -194,11 +210,12 @@ class PipeModeDatasetOp : public DatasetOpKernel {
             ~Iterator() {
                 if (benchmark_) {
                     int64_t read_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(read_time_).count();
-                    std::cout << "PipeModeDatasetOp::Dataset::Iterator read_time_ms: " << read_time_ms << std::endl;
-                    std::cout << "PipeModeDatasetOp::Dataset::Iterator read_bytes: " << read_bytes_  << std::endl;
+                    std::cout << "PipeModeDatasetOp::Dataset::Iterator total read_time_ms: " << read_time_ms
+                        << std::endl;
+                    std::cout << "PipeModeDatasetOp::Dataset::Iterator total read_bytes: " << read_bytes_  << std::endl;
                     auto read_giga_bytes = read_bytes_ / std::pow(1024, 3);
                     double read_seconds = read_time_ms / 1000.0;
-                    std::cout << "PipeModeDatasetOp::Dataset::Iterator read_GB/s: "
+                    std::cout << "PipeModeDatasetOp::Dataset::Iterator total read_GB/s: "
                         << read_giga_bytes / read_seconds << std::endl;
                 }
             }
@@ -210,6 +227,8 @@ class PipeModeDatasetOp : public DatasetOpKernel {
                 GUARDED_BY(mu_);
             std::chrono::nanoseconds read_time_;
             std::uint64_t read_bytes_;
+            std::uint64_t records_read_ = 0;
+            std::uint64_t benchmark_records_interval_;
         };
     };
 };
@@ -222,6 +241,7 @@ REGISTER_OP("PipeModeDataset")
     .Input("state_directory: string")
     .Input("channel: string")
     .Input("channel_directory: string")
+    .Input("benchmark_records_interval: uint64")
     .Output("handle: variant")
     .SetIsStateful()
     .SetShapeFn(tensorflow::shape_inference::ScalarShape);

--- a/test/unit/test_pipemode.py
+++ b/test/unit/test_pipemode.py
@@ -129,3 +129,21 @@ def test_multiple_iterators():
     assert b"caterpillar" == it.get_next()
     with pytest.raises(tf.errors.OutOfRangeError):
         it.get_next()
+
+def test_benchmark_records_interval_enabled(capfd):
+    channel, directory = write_to_channel("A", [b"bear"])
+
+    dataset = PipeModeDataset(channel, pipe_dir=directory, state_dir=directory, config_dir=directory, benchmark_records_interval=1)
+    it = iter(dataset)
+    assert it.get_next() == b"bear"
+    out, err = capfd.readouterr()
+    assert 'Iterator records' in out
+
+def test_benchmark_records_interval_disabled(capfd):
+    channel, directory = write_to_channel("A", [b"bear"])
+
+    dataset = PipeModeDataset(channel, pipe_dir=directory, state_dir=directory, config_dir=directory, benchmark_records_interval=0)
+    it = iter(dataset)
+    assert it.get_next() == b"bear"
+    out, err = capfd.readouterr()
+    assert 'Iterator records' not in out


### PR DESCRIPTION
*Description of changes:*
feature: Add parameter benchmark_records_interval to emit benchmark metrics on a configurable interval.

change: Restrict python to python3 when building the docker image for integ tests.
change: Remove g++ version specification when building the package.

*Testing*
- sudo pip3 install .
- unit testing
- integration testing
- performance testing




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
