### PR TITLE
infra: set --min-version for release process

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       # prepare the release (update versions, changelog etc.)
-      - git-release --prepare
+      - git-release --prepare --min-version 0.2.2
 
       - tox -e flake8
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
not sure how the build system got in a weird state, but it's trying to repeatedly release v0.2.1 despite that already being released

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
