### PR TITLE
Revert "infra: set --min-version for release process (#67)"

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       # prepare the release (update versions, changelog etc.)
-      - git-release --prepare --min-version 0.2.2
+      - git-release --prepare
 
       - tox -e flake8
 


### PR DESCRIPTION
This reverts commit 8f820fcfc3d8166718f97a8de452c0a1b997fd02.

I was wrong about the reason the release build was trying to push the same version again, so reverting the PR since it was unnecessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
