### PR TITLE
fix: manually bump package version and tensorflow version

### DIFF
--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -4,6 +4,7 @@ phases:
   build:
     commands:
       - PACKAGE_FILE_27="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp27-*.whl"
+      - PACKAGE_FILE_36="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp36-*.whl"
       - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
@@ -12,13 +13,16 @@ phases:
 
       - echo 'md5sum of python packages:'
       - md5sum $PACKAGE_FILE_27
+      - md5sum $PACKAGE_FILE_36
       - md5sum $PACKAGE_FILE_37
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_27
+      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_37
 
       # publish to pypi
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_27 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_37 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -3,7 +3,6 @@ version: 0.2
 phases:
   build:
     commands:
-      - PACKAGE_FILE_27="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp27-*.whl"
       - PACKAGE_FILE_36="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp36-*.whl"
       - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
@@ -12,17 +11,14 @@ phases:
       - GPG_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/password --query SecretString --output text)
 
       - echo 'md5sum of python packages:'
-      - md5sum $PACKAGE_FILE_27
       - md5sum $PACKAGE_FILE_36
       - md5sum $PACKAGE_FILE_37
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_27
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_37
 
       # publish to pypi
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_27 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_37 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -26,7 +26,7 @@ phases:
         PYTHON_VERSIONS="python3.7 python2.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==1.15 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==1.15.2 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 
@@ -36,6 +36,7 @@ phases:
 artifacts:
   files:
     - dist/sagemaker_tensorflow-*-cp27-*.whl
+    - dist/sagemaker_tensorflow-*-cp36-*.whl
     - dist/sagemaker_tensorflow-*-cp37-*.whl
   name: ARTIFACT_1
   discard-paths: yes

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -23,7 +23,7 @@ phases:
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.7 python2.7"
+        PYTHON_VERSIONS="python3.7 python3.6"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
           $PYTHON -m pip install wheel tensorflow==1.15.2 twine==1.11 cmake
@@ -35,7 +35,6 @@ phases:
 
 artifacts:
   files:
-    - dist/sagemaker_tensorflow-*-cp27-*.whl
     - dist/sagemaker_tensorflow-*-cp36-*.whl
     - dist/sagemaker_tensorflow-*-cp37-*.whl
   name: ARTIFACT_1

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,4 +13,4 @@ phases:
 
       - cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py27,py36,py37 -- test/
+      - tox -e py36,py37 -- test/

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "1.15.0"
+TF_VERSION = "1.15.2"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,6 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
     ],

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='1.15.0.1.1.0',
+    version='1.15.2.1.0.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
     cmake
     flake8
     flake8-future-import
-    tensorflow==1.15.0
+    tensorflow==1.15.2
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake
-    tensorflow==1.15.0
+    tensorflow==1.15.2
     cpplint

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist
     mock
     contextlib2
-    tensorflow==1.15.0
+    tensorflow==1.15.2
     awslogs
     docker
     cmake


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
bump tensorflow 1.x version to 1.15.2.
manually bump package version.
release py27, py36 and py37

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
