### PR TITLE
doc: clarify support for TF2 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ SageMaker TensorFlow
 
 SageMaker specific extensions to TensorFlow, for Python 2.7, 3.4-3.7 and TensorFlow versions 1.7-1.15.2 (Python 3.7 support is only available for TensorFlow 1.15.2), and for Python 3.6-3.7. This package includes the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
+TensorFlow 2 support is available on the tf-2 branch. TensorFlow 2 releases are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_ for release versions beginning with 2.
+
 Install
 -------
 You can build SageMaker TensorFlow into a docker image with the following command:

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -11,13 +11,10 @@
 // ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-#include <nsync.h>
-#include <sys/stat.h>
-
-#include <chrono>
-#include <iostream>
-#include <string>
-#include <thread>
+#include "PipeStateManager.pp"
+#include "RecordIOReader.hpp"
+#include "TextLineRecordReader.hpp"
+#include "TFRecordReader.hpp"
 
 #include "tensorflow/core/framework/common_shape_fns.h"
 #include "tensorflow/core/framework/op.h"
@@ -25,10 +22,13 @@
 #include "tensorflow/core/framework/shape_inference.h"
 #include "tensorflow/core/framework/dataset.h"
 
-#include "PipeStateManager.hpp"
-#include "RecordIOReader.hpp"
-#include "TextLineRecordReader.hpp"
-#include "TFRecordReader.hpp"
+#include <nsync.h>
+#include <sys/stat.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
 
 using sagemaker::tensorflow::PipeStateManager;
 using sagemaker::tensorflow::RecordIOReader;

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -11,11 +11,6 @@
 // ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-#include "PipeStateManager.hpp"
-#include "RecordIOReader.hpp"
-#include "TextLineRecordReader.hpp"
-#include "TFRecordReader.hpp"
-
 #include <sys/stat.h>
 
 #include <chrono>
@@ -30,6 +25,11 @@
 #include "tensorflow/core/framework/op_def_builder.h"
 #include "tensorflow/core/framework/shape_inference.h"
 #include "tensorflow/core/framework/dataset.h"
+
+#include "PipeStateManager.hpp"
+#include "RecordIOReader.hpp"
+#include "TextLineRecordReader.hpp"
+#include "TFRecordReader.hpp"
 
 using sagemaker::tensorflow::PipeStateManager;
 using sagemaker::tensorflow::RecordIOReader;

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -16,13 +16,14 @@
 #include "TextLineRecordReader.hpp"
 #include "TFRecordReader.hpp"
 
-#include <nsync.h>
 #include <sys/stat.h>
 
 #include <chrono>
 #include <iostream>
 #include <string>
 #include <thread>
+
+#include <nsync.h>
 
 #include "tensorflow/core/framework/common_shape_fns.h"
 #include "tensorflow/core/framework/op.h"

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -11,7 +11,7 @@
 // ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-#include "PipeStateManager.pp"
+#include "PipeStateManager.hpp"
 #include "RecordIOReader.hpp"
 #include "TextLineRecordReader.hpp"
 #include "TFRecordReader.hpp"

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -16,12 +16,6 @@
 #include "TextLineRecordReader.hpp"
 #include "TFRecordReader.hpp"
 
-#include "tensorflow/core/framework/common_shape_fns.h"
-#include "tensorflow/core/framework/op.h"
-#include "tensorflow/core/framework/op_def_builder.h"
-#include "tensorflow/core/framework/shape_inference.h"
-#include "tensorflow/core/framework/dataset.h"
-
 #include <nsync.h>
 #include <sys/stat.h>
 
@@ -29,6 +23,12 @@
 #include <iostream>
 #include <string>
 #include <thread>
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_def_builder.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/dataset.h"
 
 using sagemaker::tensorflow::PipeStateManager;
 using sagemaker::tensorflow::RecordIOReader;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-tensorflow-extensions/issues/71

*Description of changes:*
Adds a line to the README pointing users to the correct branch and PyPI releases for TensorFLow 2 support.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
