### PR TITLE
infra: fix cpplint invocation in release buildspec

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -15,7 +15,7 @@ phases:
 
       - tox -e flake8
 
-      - cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
+      - python3.7 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
       - tox -e py36,py37 -- test/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
changing this to match the PR buildspec - now the cpplint invocation doesn't make assumptions about the default Python version in the CodeBuild image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
