### PR TITLE
Updated broken link to homepage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     ext_modules=[CMakeExtension(name='pipemode_op', sourcedir='src/pipemode_op')],
     cmdclass=dict(build_ext=CMakeBuild),
     long_description=read('README.rst'),
-    url='https://github.com/aws/sagemaker-tensorflow',
+    url='https://github.com/aws/sagemaker-tensorflow-extensions',
     license='Apache License 2.0',
     author='Amazon Web Services',
     maintainer='Amazon Web Services',


### PR DESCRIPTION
*Issue:*
According to pypi sagemaker-tensorflow page:
https://pypi.org/project/sagemaker-tensorflow/2.3.0.1.0.0/#modal-close

The home page of the package is:
https://github.com/aws/sagemaker-tensorflow

But when you try to follow the link you get 404 error.

*Description of changes:*
Updated link to point to point to this GitHub repo: https://github.com/aws/sagemaker-tensorflow-extensions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
