### PR TITLE
fix: add py37 support for sagemaker-tensorflow library

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -26,7 +26,7 @@ phases:
         PYTHON_VERSIONS="python3.7 python3.6"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==1.15.2 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==1.13.1 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,13 +9,13 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "1.15.2"
+TF_VERSION = "1.13.1"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('device', nargs='?', default='cpu')
+    parser.add_argument('devce', nargs='?', default='cpu')
     args = parser.parse_args()
 
     client = docker.from_env()

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -15,7 +15,7 @@ REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('devce', nargs='?', default='cpu')
+    parser.add_argument('device', nargs='?', default='cpu')
     args = parser.parse_args()
 
     client = docker.from_env()

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='1.15.2.1.0.0',
+    version='1.13.1.2.0.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/src/pipemode_op/PipeStateManager/PipeStateManager.cpp
+++ b/src/pipemode_op/PipeStateManager/PipeStateManager.cpp
@@ -14,6 +14,7 @@
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <fstream>
 #include <iostream>
 #include <ios>
@@ -70,4 +71,5 @@ Lock::Lock(const std::string& lock_file) {
 
 Lock::~Lock() {
     check(flock(fd_, LOCK_UN));
+    close(fd_);
 }

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist
     mock
     contextlib2
-    tensorflow==1.15.2
+    tensorflow==1.13.1
     awslogs
     docker
     cmake
@@ -61,7 +61,7 @@ deps =
     cmake
     flake8
     flake8-future-import
-    tensorflow==1.15.2
+    tensorflow==1.13.1
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake
-    tensorflow==1.15.2
+    tensorflow==1.13.1
     cpplint


### PR DESCRIPTION
*Issue #, if available:*
sagemaker-tensorflow 1.13.1 does not have py37 support

*Description of changes:*
adding py37 support for sagemaker-tensorflow 1.13.1.2.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
