### PR TITLE
change: bump tensorflow version to 2.3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.6-3.7 and TensorFlow versions 1.7 and higher, including 2.0-2.2.
+This package supports Python 3.6-3.8 and TensorFlow versions 1.7 and higher, including 2.0-2.3.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -14,7 +14,7 @@ phases:
       - echo 'md5sum of python packages:'
       - md5sum $PACKAGE_FILE_36
       - md5sum $PACKAGE_FILE_37
-      - PACKAGE_FILE_38
+      - md5sum $PACKAGE_FILE_38
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -5,6 +5,7 @@ phases:
     commands:
       - PACKAGE_FILE_36="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp36-*.whl"
       - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
+      - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
@@ -13,12 +14,15 @@ phases:
       - echo 'md5sum of python packages:'
       - md5sum $PACKAGE_FILE_36
       - md5sum $PACKAGE_FILE_37
+      - PACKAGE_FILE_38
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_36
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_37
+      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_38
 
       # publish to pypi
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_36 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_37 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -5,7 +5,7 @@ phases:
     commands:
       - apt-get update
       - apt-get -y install libcurl4-openssl-dev g++-5
-      - python3.7 -m pip install cpplint
+      - python3.8 -m pip install cpplint
       - start-dockerd
 
   build:
@@ -15,18 +15,18 @@ phases:
 
       - tox -e flake8
 
-      - python3.7 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
+      - python3.8 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
-      - tox -e py36,py37 -- test/
+      - tox -e py36,py37,py38 -- test/
 
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.7 python3.6"
+        PYTHON_VERSIONS="python3.8 python3.7 python3.6"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.3.0 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.3.1 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 
@@ -37,5 +37,6 @@ artifacts:
   files:
     - dist/sagemaker_tensorflow-*-cp36-*.whl
     - dist/sagemaker_tensorflow-*-cp37-*.whl
+    - dist/sagemaker_tensorflow-*-cp38-*.whl
   name: ARTIFACT_1
   discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,12 +5,12 @@ phases:
     commands:
       - apt-get update
       - apt-get -y install libcurl4-openssl-dev g++-7
-      - python3.7 -m pip install cpplint
+      - python3.8 -m pip install cpplint
       - start-dockerd
   build:
     commands:
       - tox -e flake8
 
-      - python3.7 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
+      - python3.8 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py36,py37 -- test/
+      - tox -e py36,py37,py3.8 -- test/

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,4 +13,4 @@ phases:
 
       - python3.8 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py36,py37,py3.8 -- test/
+      - tox -e py36,py37,py38 -- test/

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.3.0"
+TF_VERSION = "2.3.1"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.3.0.1.0.0',
+    version='2.3.1.0.0.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},
@@ -118,6 +118,7 @@ setup(
         "Programming Language :: Python",
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',


### PR DESCRIPTION
*Issue #, if available:*
tensorflow released 2.3.1: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
no breaking changes

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
