### PR TITLE
fix: throw an exception for invalid return value from RecordReader::Read

### DIFF
--- a/src/pipemode_op/RecordReader/RecordReader.cpp
+++ b/src/pipemode_op/RecordReader/RecordReader.cpp
@@ -66,6 +66,9 @@ std::size_t RecordReader::Read(void* dest, std::size_t nbytes) {
     std::size_t bytes_read = 0;
     while (nbytes) {
         ssize_t read_amount = read(fd_, dest + bytes_read, std::min(nbytes, read_size_));
+        if (-1 == read_amount) {
+            throw std::system_error(errno, std::system_category());
+        }
         if (!read_amount) {
             break;
         }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
