### PR TITLE
feature: allow skipping corrupt TFRecords

### DIFF
--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -89,6 +89,7 @@ class PipeModeDatasetOp : public DatasetOpKernel {
         std::string channel;
         bool benchmark;
         std::uint64_t benchmark_records_interval;
+        std::uint32_t max_corrupted_records_to_skip;
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::string>(ctx, "record_format",
                                                         &record_format));
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::string>(ctx, "state_directory",
@@ -103,30 +104,34 @@ class PipeModeDatasetOp : public DatasetOpKernel {
                                                         &benchmark));
         OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::uint64_t>(ctx, "benchmark_records_interval",
                                                         &benchmark_records_interval));
+        OP_REQUIRES_OK(ctx, tensorflow::data::ParseScalarArgument<std::uint32_t>(ctx, "max_corrupted_records_to_skip",
+                                                        &max_corrupted_records_to_skip));
+
         *output = new Dataset(ctx, record_format, state_directory, channel_directory, channel, benchmark,
-                              benchmark_records_interval);
+                              benchmark_records_interval, max_corrupted_records_to_skip);
     }
 
  private:
     class Dataset : public DatasetBase {
      public:
-        explicit Dataset(OpKernelContext* ctx, const std::string& record_format, const std::string& state_directory,
+    explicit Dataset(OpKernelContext* ctx, const std::string& record_format, const std::string& state_directory,
             const std::string& channel_directory, const std::string& channel, bool benchmark,
-            std::uint64_t benchmark_records_interval):
+            std::uint64_t benchmark_records_interval, const std::uint32_t max_corrupted_records_to_skip):
             DatasetBase(DatasetContext(ctx)),
             record_format_(record_format),
             channel_directory_(channel_directory),
             pipe_state_manager_(state_directory, channel),
             channel_(channel),
             benchmark_(benchmark),
-            benchmark_records_interval_(benchmark_records_interval) {}
+            benchmark_records_interval_(benchmark_records_interval),
+            max_corrupted_records_to_skip_(max_corrupted_records_to_skip) {}
 
         std::unique_ptr<IteratorBase> MakeIteratorInternal(const std::string& prefix) const override {
             auto new_prefix = prefix + "::PipeMode-" + channel_ + "-"
                 + std::to_string(pipe_state_manager_.GetPipeIndex());
             auto ptr = std::unique_ptr<IteratorBase>(
                 new Iterator({this, new_prefix}, record_format_, channel_directory_, channel_, benchmark_,
-                    pipe_state_manager_.GetPipeIndex(), benchmark_records_interval_));
+                    pipe_state_manager_.GetPipeIndex(), benchmark_records_interval_, max_corrupted_records_to_skip_));
             pipe_state_manager_.IncrementPipeIndex();
             return ptr;
         }
@@ -158,19 +163,22 @@ class PipeModeDatasetOp : public DatasetOpKernel {
         PipeStateManager pipe_state_manager_;
         bool benchmark_;
         std::uint64_t benchmark_records_interval_;
+        std::uint32_t max_corrupted_records_to_skip_;
 
         class Iterator : public DatasetIterator<Dataset> {
          public:
             explicit Iterator(const Params& params, const std::string& record_format,
                 const std::string& channel_directory, const std::string& channel, const bool benchmark,
-                const uint32_t pipe_index, const uint64_t benchmark_records_interval)
+                const uint32_t pipe_index, const uint64_t benchmark_records_interval,
+                const uint32_t max_corrupted_records_to_skip)
                 : DatasetIterator<Dataset>(params), read_time_(0), read_bytes_(0),
                     benchmark_(benchmark), benchmark_records_interval_(benchmark_records_interval) {
                     std::string pipe_path = BuildPipeName(channel_directory, channel, pipe_index);
                     if (record_format == "RecordIO") {
                         record_reader_ = std::unique_ptr<RecordReader>(new RecordIOReader(pipe_path));
                     } else if (record_format == "TFRecord") {
-                        record_reader_ = std::unique_ptr<RecordReader>(new TFRecordReader(pipe_path));
+                        record_reader_ = std::unique_ptr<RecordReader>(
+                            new TFRecordReader(pipe_path, max_corrupted_records_to_skip));
                     } else {  // required to be TextLine
                         record_reader_ = std::unique_ptr<RecordReader>(new TextLineRecordReader(pipe_path));
                     }
@@ -242,6 +250,7 @@ REGISTER_OP("PipeModeDataset")
     .Input("channel: string")
     .Input("channel_directory: string")
     .Input("benchmark_records_interval: uint64")
+    .Input("max_corrupted_records_to_skip: uint32")
     .Output("handle: variant")
     .SetIsStateful()
     .SetShapeFn(tensorflow::shape_inference::ScalarShape);

--- a/src/pipemode_op/RecordReader/TFRecordReader.hpp
+++ b/src/pipemode_op/RecordReader/TFRecordReader.hpp
@@ -30,7 +30,37 @@ class TFRecordReader : public RecordReader {
     using RecordReader::RecordReader;
 
  public:
+     /**
+       Constructs a new RecordReader that reads records from a file.
+
+       param [in] file_path: The path and name of the file to open.
+       param [in] read_size: The preferred number of bytes to read from the open file
+                             during invocation of Read.
+       param [in] file_creation_timeout: The number of seconds to wait for the file
+                                         being read to exist.
+     */
+    TFRecordReader(const std::string& file_path, const std::size_t read_size,
+                 const std::chrono::seconds file_creation_timeout,
+                 const uint32_t max_corrupted_records_to_skip):
+                 RecordReader(file_path, read_size, file_creation_timeout),
+                 max_corrupted_records_to_skip_(max_corrupted_records_to_skip) {}
+
+     /**
+       Constructs a new TFRecordReader that reads records from a file.
+
+       param [in] file_path: The path and name of the file to open.
+       param [in] max_corrupted_records_to_skip: the number of corrupted records
+                             encountered in sequence that it's ok to skip.
+     */
+    TFRecordReader(const std::string& file_path,
+                   const uint32_t max_corrupted_records_to_skip = 0):
+                 RecordReader(file_path),
+                 max_corrupted_records_to_skip_(max_corrupted_records_to_skip) {}
+
     bool ReadRecord(std::string* storage) override;
+
+ private:
+    std::uint32_t max_corrupted_records_to_skip_;
 };
 
 }  // namespace tensorflow

--- a/src/sagemaker_tensorflow/pipemode.py
+++ b/src/sagemaker_tensorflow/pipemode.py
@@ -41,7 +41,8 @@ class PipeModeDataset(dataset_ops.Dataset):
 
     def __init__(self, channel, record_format='RecordIO',
                  state_dir='/opt/ml/pipe_state', pipe_dir='/opt/ml/input/data',
-                 config_dir='/opt/ml/input/config', benchmark=False, benchmark_records_interval=0):
+                 config_dir='/opt/ml/input/config', benchmark=False, benchmark_records_interval=0,
+                 max_corrupted_records_to_skip=0):
         """Create a Dataset for reading from a SageMaker PipeMode channel.
 
         Supports records encoded using either RecordIO, TFRecord, or new line text encoding.
@@ -59,6 +60,8 @@ class PipeModeDataset(dataset_ops.Dataset):
                     read from this Dataset. Defines the number of records per interval to emit timing and throughput
                     metrics. If zero, no metrics will be emitted while records are being read from this Dataset.
                     Metrics are emitted to stdout.
+            max_corrupted_records_to_skip: the number of corrupted records encountered in sequence that it's ok to
+                    skip. Only applicable for record_format='TFRecord'.
         """
         try:
             os.makedirs(state_dir)
@@ -71,14 +74,20 @@ class PipeModeDataset(dataset_ops.Dataset):
         self.state_dir = state_dir
         self.benchmark = benchmark
         self.benchmark_records_interval = benchmark_records_interval
+        self.max_corrupted_records_to_skip = max_corrupted_records_to_skip
         with open(os.path.join(config_dir, 'inputdataconfig.json')) as f:
             self.input_data_config = json.load(f)
         self._validate_input_data_config()
+
+        if self.max_corrupted_records_to_skip > 0 and record_format != 'TFRecord':
+            raise PipeModeDatasetException("max_corrupted_records_to_skip can only be set for record_format='TFRecord'")
+
         super(PipeModeDataset, self).__init__()
 
     def _as_variant_tensor(self):
         return self._tf_plugin.pipe_mode_dataset(self.benchmark, self.record_format, self.state_dir, self.channel,
-                                                 self.pipe_dir, self.benchmark_records_interval)
+                                                 self.pipe_dir, self.benchmark_records_interval,
+                                                 self.max_corrupted_records_to_skip)
 
     def _inputs(self):
         return []


### PR DESCRIPTION
We've noticed records failing CRC checks very intermittently (tests
demonstrate one in 645 million TFRecords failing these CRC checks).

We've been unable to find the root cause for these failures but as a
workaround we're adding a new parameter: `max_corrupted_records_to_skip`
which will allow the pipe reader to skip these occasional corrupted
records without failing.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
