### PR TITLE
feature: allow skipping corrupt TFRecords

### DIFF
--- a/src/pipemode_op/RecordReader/TFRecordReader.hpp
+++ b/src/pipemode_op/RecordReader/TFRecordReader.hpp
@@ -33,7 +33,37 @@ class TFRecordReader : public RecordReader {
     using RecordReader::RecordReader;
 
  public:
+     /**
+       Constructs a new RecordReader that reads records from a file.
+
+       param [in] file_path: The path and name of the file to open.
+       param [in] read_size: The preferred number of bytes to read from the open file
+                             during invocation of Read.
+       param [in] file_creation_timeout: The number of seconds to wait for the file
+                                         being read to exist.
+     */
+    TFRecordReader(const std::string& file_path, const std::size_t read_size,
+                 const std::chrono::seconds file_creation_timeout,
+                 const uint32_t max_corrupted_records_to_skip):
+                 RecordReader(file_path, read_size, file_creation_timeout),
+                 max_corrupted_records_to_skip_(max_corrupted_records_to_skip) {}
+
+     /**
+       Constructs a new TFRecordReader that reads records from a file.
+
+       param [in] file_path: The path and name of the file to open.
+       param [in] max_corrupted_records_to_skip: the number of corrupted records
+                             encountered in sequence that it's ok to skip.
+     */
+    TFRecordReader(const std::string& file_path,
+                   const uint32_t max_corrupted_records_to_skip = 0):
+                 RecordReader(file_path),
+                 max_corrupted_records_to_skip_(max_corrupted_records_to_skip) {}
+
     bool ReadRecord(::tensorflow::tstring* storage) override;
+
+ private:
+    std::uint32_t max_corrupted_records_to_skip_;
 };
 
 }  // namespace tensorflow

--- a/src/pipemode_op/test/testRecordReader/TestTFRecordReader.cpp
+++ b/src/pipemode_op/test/testRecordReader/TestTFRecordReader.cpp
@@ -35,8 +35,9 @@ void TFRecordReaderTest::SetUp() {}
 void TFRecordReaderTest::TearDown() {}
 
 std::unique_ptr<TFRecordReader> MakeTFRecordReader(std::string path,
-    std::size_t read_size) {
-    return std::unique_ptr<TFRecordReader>(new TFRecordReader(path, read_size, std::chrono::seconds(1)));
+    std::size_t read_size, uint32_t max_corrupted_records_to_skip = 0) {
+    return std::unique_ptr<TFRecordReader>(
+        new TFRecordReader(path, read_size, std::chrono::seconds(1), max_corrupted_records_to_skip));
 }
 
 std::unique_ptr<TFRecordReader> MakeTFRecordReader(std::string path) {
@@ -83,6 +84,71 @@ TEST_F(TFRecordReaderTest, ReadRecordFails) {
     std::unique_ptr<TFRecordReader> reader = MakeTFRecordReader(
         CreateChannel(CreateTemporaryDirectory(), "elizabeth", "not a record", 0), 4);
     tensorflow::tstring record;
+    EXPECT_THROW({
+        reader->ReadRecord(&record);},
+        std::runtime_error);
+}
+
+TEST_F(TFRecordReaderTest, ReadMultipleRecords) {
+    std::string rec1 = ToTFRecord("hello");
+    std::string rec2 = ToTFRecord("world");
+    std::string encoded = rec1 + rec2;
+    std::unique_ptr<TFRecordReader> reader = MakeTFRecordReader(
+        CreateChannel(CreateTemporaryDirectory(), "elizabeth", encoded, 0), 4);
+    tensorflow::tstring record;
+    reader->ReadRecord(&record);
+    EXPECT_EQ("hello", record);
+    reader->ReadRecord(&record);
+    EXPECT_EQ("world", record);
+    EXPECT_FALSE(reader->ReadRecord(&record));
+}
+
+TEST_F(TFRecordReaderTest, FailOnCorruptRecord) {
+    // this test fails as soon as a corrupt record is encountered in the record stream
+    std::string rec1 = ToTFRecord("hello");
+    std::string rec2 = ToTFRecord("world");
+    std::string corrupted = rec2;
+    corrupted[corrupted.length() - 1] = 'x';
+    std::string encoded = rec1 + corrupted;
+    std::unique_ptr<TFRecordReader> reader = MakeTFRecordReader(
+        CreateChannel(CreateTemporaryDirectory(), "elizabeth", encoded, 0), 4);
+    tensorflow::tstring record;
+    reader->ReadRecord(&record);
+    EXPECT_EQ("hello", record);
+    EXPECT_THROW({
+        reader->ReadRecord(&record);},
+        std::runtime_error);
+}
+
+TEST_F(TFRecordReaderTest, SkipCorruptRecords) {
+    // in this test we confiigure the reader to tolerate upto 3 consecutive corrupt records
+    // and then insert 3 corrupt records into the record stream and see that we skip and
+    // parse the next kosher record, however, immediately following it we have 4 corrupt
+    // records which will fail parsing the rest of the stream
+    uint32_t max_corrupt_records_to_skip = 3;
+    std::string rec1 = ToTFRecord("hello");
+    std::string rec2 = ToTFRecord("world");
+    std::string corrupted = rec2;
+    corrupted[corrupted.length() - 1] = 'x';
+    std::string encoded = rec1;
+    for (int i = 0; i < max_corrupt_records_to_skip; i++) {
+        encoded.append(corrupted);
+    }
+    encoded.append(rec2);
+    for (int i = 0; i < max_corrupt_records_to_skip + 1; i++) {
+        encoded.append(corrupted);
+    }
+
+    std::unique_ptr<TFRecordReader> reader = MakeTFRecordReader(
+        CreateChannel(CreateTemporaryDirectory(), "elizabeth", encoded, 0), 4, max_corrupt_records_to_skip);
+    tensorflow::tstring record;
+    reader->ReadRecord(&record);
+    EXPECT_EQ("hello", record);
+     // swallow the upto max_corrupt_records_to_skip corrupted recs and successfully parse the next one:
+    reader->ReadRecord(&record);
+    EXPECT_EQ("world", record);
+
+    // but the next set of corrupted records exceed max_corrupt_records_to_skip, so we get an error:
     EXPECT_THROW({
         reader->ReadRecord(&record);},
         std::runtime_error);


### PR DESCRIPTION
We've noticed records failing CRC checks very intermittently (tests
demonstrate one in 645 million TFRecords failing these CRC checks).

We've been unable to find the root cause for these failures but as a
workaround we're adding a new parameter: `max_corrupted_records_to_skip`
which will allow the pipe reader to skip these occasional corrupted
records without failing.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
