### PR TITLE
fix: update package minor version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='1.15.2.1.0.0',
+    version='1.15.2.1.1.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to: https://github.com/aws/sagemaker-tensorflow-extensions/pull/114. It seems that the version has to be bumped manually for this package.

Raising minor version for: https://github.com/aws/sagemaker-tensorflow-extensions/pull/120

Following minor version semantics in https://www.python.org/dev/peps/pep-0440/ as a feature was released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
