### PR TITLE
Update buildspec to allow gcc9 installs

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -4,10 +4,14 @@ phases:
   pre_build:
     commands:
       - apt-get update
-      - apt-get -y install libcurl4-openssl-dev g++-9
+      - apt install software-properties-common
+      - add-apt-repository ppa:ubuntu-toolchain-r/test
+      - apt-get -y install libcurl4-openssl-dev g++-9 gcc-9
+
+      # Confirm GCC install went through because it fails silently sometimes
+      - echo $(ls /usr/bin/)
       - python3.8 -m pip install cpplint
       - start-dockerd
-
   build:
     commands:
       # prepare the release (update versions, changelog etc.)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,9 +4,15 @@ phases:
   pre_build:
     commands:
       - apt-get update
-      - apt-get -y install libcurl4-openssl-dev g++-9
+      - apt install software-properties-common
+      - add-apt-repository ppa:ubuntu-toolchain-r/test
+      - apt-get -y install libcurl4-openssl-dev g++-9 gcc-9
+
+      # Confirm GCC install went through because it fails silently sometimes
+      - echo $(ls /usr/bin/)
       - python3.8 -m pip install cpplint
       - start-dockerd
+
   build:
     commands:
       - tox -e flake8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Download necessary apt repositories and install gcc9 while performing CI build across build projects

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
