### PR TITLE
feature: Support TensorFlow 2.10.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.7-3.9 and TensorFlow versions 1.7 and higher, including 2.0-2.9.1.
+This package supports Python 3.7-3.9 and TensorFlow versions 1.7 and higher, including 2.0-2.10.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -97,6 +97,10 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
+   * - 2.10.0.1.16.x
+     - v1.16.x
+     - 2.10.0
+     - 3.7, 3.8, 3.9
    * - 2.9.1.1.15.x
      - v1.15.x
      - 2.9.1

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -26,7 +26,7 @@ phases:
         PYTHON_VERSIONS="python3.9 python3.8 python3.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.9.1 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.10.0 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.10.0rc3"
+TF_VERSION = "2.10.0"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.9.1"
+TF_VERSION = "2.10.0rc3"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.9.1.1.15.0',
+    version='2.10.0.1.16.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/src/pipemode_op/CMakeLists.txt
+++ b/src/pipemode_op/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 enable_language(CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CURL_LIBRARY "-lcurl") 
+set(CURL_LIBRARY "-lcurl")
 
-find_package(CURL REQUIRED) 
+find_package(CURL REQUIRED)
 
 project(TFPipeModeDataset)
 

--- a/src/pipemode_op/Dataset/CMakeLists.txt
+++ b/src/pipemode_op/Dataset/CMakeLists.txt
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_VERBOSE_MAKEFILE on )
 
@@ -33,7 +33,7 @@ execute_process(COMMAND "$ENV{PYTHON_EXECUTABLE}" "-c"
 	"import tensorflow as tf; import sys; sys.stdout.write(tf.sysconfig.get_include() + '/')"
 	OUTPUT_VARIABLE TF_INCLUDE_DIR)
 
-find_library(TF_LIB 
+find_library(TF_LIB
 	NAMES libtensorflow_framework.so.2
 	PATHS "${TF_LIB_DIR}"
 	NO_DEFAULT_PATH)

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.9.1
+ARG tensorflow_version=2.10.0
 ARG script
 ARG python
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.9.1
+    tensorflow==2.10.0
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.9.1
+    tensorflow==2.10.0
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.9.1
+    tensorflow==2.10.0
     cpplint==1.5.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrading sagemaker-tensorflow-extensions to support new tensorflow-extensions v2.10.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
