### PR TITLE
Support TensorFlow 2.11.0 and Python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.7-3.9 and TensorFlow versions 1.7 and higher, including 2.0-2.10.0.
+This package supports Python 3.7-3.9 and TensorFlow versions 1.7 and higher, including 2.0-2.11.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -97,6 +97,10 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
+   * - 2.11.0.1.17.x
+     - v1.17.x
+     - 2.11.0
+     - 3.7, 3.8, 3.9
    * - 2.10.0.1.16.x
      - v1.16.x
      - 2.10.0

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Please refer to below table for release support information:
    * - 2.11.0.1.17.x
      - v1.17.x
      - 2.11.0
-     - 3.7, 3.8, 3.9
+     - 3.7, 3.8, 3.9, 3.10
    * - 2.10.0.1.16.x
      - v1.16.x
      - 2.10.0

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.7-3.9 and TensorFlow versions 1.7 and higher, including 2.0-2.11.0.
+This package supports Python 3.7-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.11.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -85,7 +85,7 @@ Release branching is used to track different versions of TensorFlow. To build fo
 
 Requirements
 ------------
-SageMaker TensorFlow extensions builds on Python 3.4-3.9 in Linux with a TensorFlow version >= 1.7. Older versions of TensorFlow are not supported. Please make sure to checkout the branch of sagemaker-tensorflow-extensions that matches your TensorFlow version.
+SageMaker TensorFlow extensions builds on Python 3.4-3.10 in Linux with a TensorFlow version >= 1.7. Older versions of TensorFlow are not supported. Please make sure to checkout the branch of sagemaker-tensorflow-extensions that matches your TensorFlow version.
 
 Please refer to below table for release support information:
 

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -6,6 +6,7 @@ phases:
       - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
       - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
+      - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
@@ -15,14 +16,17 @@ phases:
       - md5sum $PACKAGE_FILE_37
       - md5sum $PACKAGE_FILE_38
       - md5sum $PACKAGE_FILE_39
+      - md5sum $PACKAGE_FILE_310
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_37
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_38
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_39
+      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_310
 
       # publish to pypi
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_37 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -6,7 +6,7 @@ phases:
       - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
       - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
-      - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
+      - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp310-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -26,7 +26,7 @@ phases:
         PYTHON_VERSIONS="python3.9 python3.8 python3.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.10.0 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.11.0rc1 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -26,7 +26,7 @@ phases:
         PYTHON_VERSIONS="python3.10 python3.9 python3.8 python3.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.11.0rc1 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.11.0 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -15,15 +15,15 @@ phases:
 
       - tox -e flake8
 
-      - python3.9 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
+      - python3.10 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
-      - tox -e py37,py38,py39 -- test/
+      - tox -e py37,py38,py39,py310 -- test/
 
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.9 python3.8 python3.7"
+        PYTHON_VERSIONS="python3.10 python3.9 python3.8 python3.7"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
           $PYTHON -m pip install wheel tensorflow==2.11.0rc1 twine==1.11 cmake
@@ -38,5 +38,6 @@ artifacts:
     - dist/sagemaker_tensorflow-*-cp37-*.whl
     - dist/sagemaker_tensorflow-*-cp38-*.whl
     - dist/sagemaker_tensorflow-*-cp39-*.whl
+    - dist/sagemaker_tensorflow-*-cp310-*.whl
   name: ARTIFACT_1
   discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,12 +5,12 @@ phases:
     commands:
       - apt-get update
       - apt-get -y install libcurl4-openssl-dev g++-9
-      - python3.9 -m pip install cpplint==1.5.5
+      - python3.10 -m pip install cpplint==1.5.5
       - start-dockerd
   build:
     commands:
       - tox -e flake8
 
-      - python3.9 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
+      - python3.10 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py37,py38,py39 -- test/
+      - tox -e py37,py38,py39,py310 -- test/

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.11.0rc1"
+TF_VERSION = "2.11.0"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.10.0"
+TF_VERSION = "2.11.0rc1"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.10.0.1.16.0',
+    version='2.11.0rc1.1.17.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.11.0rc1.1.17.0',
+    version='2.11.0.1.17.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/src/pipemode_op/include/tensorflow/core/lib/hash/crc32c.h
+++ b/src/pipemode_op/include/tensorflow/core/lib/hash/crc32c.h
@@ -1,8 +1,11 @@
 /* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -10,43 +13,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_LIB_HASH_CRC32C_H_
-#define TENSORFLOW_LIB_HASH_CRC32C_H_
+#ifndef TENSORFLOW_CORE_LIB_HASH_CRC32C_H_
+#define TENSORFLOW_CORE_LIB_HASH_CRC32C_H_
 
 #include <stddef.h>
 
-typedef unsigned int uint32;
+#include "tensorflow/tsl/lib/hash/crc32c.h"
 
 namespace tensorflow {
 namespace crc32c {
-
-// Return the crc32c of concat(A, data[0,n-1]) where init_crc is the
-// crc32c of some string A.  Extend() is often used to maintain the
-// crc32c of a stream of data.
-extern uint32 Extend(uint32 init_crc, const char* data, size_t n);
-
-// Return the crc32c of data[0,n-1]
-inline uint32 Value(const char* data, size_t n) { return Extend(0, data, n); }
-
-static const uint32 kMaskDelta = 0xa282ead8ul;
-
-// Return a masked representation of crc.
-//
-// Motivation: it is problematic to compute the CRC of a string that
-// contains embedded CRCs.  Therefore we recommend that CRCs stored
-// somewhere (e.g., in files) should be masked before being stored.
-inline uint32 Mask(uint32 crc) {
-  // Rotate right by 15 bits and add a constant.
-  return ((crc >> 15) | (crc << 17)) + kMaskDelta;
-}
-
-// Return the crc whose masked representation is masked_crc.
-inline uint32 Unmask(uint32 masked_crc) {
-  uint32 rot = masked_crc - kMaskDelta;
-  return ((rot >> 17) | (rot << 15));
-}
-
+// NOLINTBEGIN(misc-unused-using-decls)
+using tsl::crc32c::Extend;
+using tsl::crc32c::kMaskDelta;
+using tsl::crc32c::Mask;
+using tsl::crc32c::Unmask;
+using tsl::crc32c::Value;
+// NOLINTEND(misc-unused-using-decls)
 }  // namespace crc32c
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_LIB_HASH_CRC32C_H_
+#endif  // TENSORFLOW_CORE_LIB_HASH_CRC32C_H_

--- a/src/pipemode_op/include/tensorflow/tsl/lib/hash/crc32c.h
+++ b/src/pipemode_op/include/tensorflow/tsl/lib/hash/crc32c.h
@@ -1,0 +1,57 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_TSL_LIB_HASH_CRC32C_H_
+#define TENSORFLOW_TSL_LIB_HASH_CRC32C_H_
+
+#include <stddef.h>
+
+namespace tsl {
+namespace crc32c {
+
+typedef unsigned int uint32;
+
+// Return the crc32c of concat(A, buf[0,size-1]) where init_crc is the
+// crc32c of some string A.  Extend() is often used to maintain the
+// crc32c of a stream of data.
+extern uint32 Extend(uint32 init_crc, const char* buf, size_t size);
+
+
+// Return the crc32c of data[0,n-1]
+inline uint32 Value(const char* data, size_t n) { return Extend(0, data, n); }
+
+static const uint32 kMaskDelta = 0xa282ead8ul;
+
+// Return a masked representation of crc.
+//
+// Motivation: it is problematic to compute the CRC of a string that
+// contains embedded CRCs.  Therefore we recommend that CRCs stored
+// somewhere (e.g., in files) should be masked before being stored.
+inline uint32 Mask(uint32 crc) {
+  // Rotate right by 15 bits and add a constant.
+  return ((crc >> 15) | (crc << 17)) + kMaskDelta;
+}
+
+// Return the crc whose masked representation is masked_crc.
+inline uint32 Unmask(uint32 masked_crc) {
+  uint32 rot = masked_crc - kMaskDelta;
+  return ((rot >> 17) | (rot << 15));
+}
+
+}  // namespace crc32c
+}  // namespace tsl
+
+#endif  // TENSORFLOW_TSL_LIB_HASH_CRC32C_H_
+

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.11.0rc1
+ARG tensorflow_version=2.11.0
 ARG script
 ARG python
 

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.10.0
+ARG tensorflow_version=2.11.0rc1
 ARG script
 ARG python
 

--- a/test/recordio_utils.py
+++ b/test/recordio_utils.py
@@ -62,7 +62,7 @@ def write_recordio_multipart(f, data):
 
 
 def string_feature(value):
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value.tostring()]))
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value.tobytes()]))
 
 
 def label_feature(value):

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.10.0
+    tensorflow==2.11.0rc1
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.10.0
+    tensorflow==2.11.0rc1
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.10.0
+    tensorflow==2.11.0rc1
     cpplint==1.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,flake8,cpplint
+envlist = py37,py38,py39,py310,flake8,cpplint
 
 skip_missing_interpreters = False
 
@@ -50,18 +50,18 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.11.0rc1
+    tensorflow==2.11.0rc2
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.10
 deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.11.0rc1
+    tensorflow==2.11.0rc2
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.11.0rc1
+    tensorflow==2.11.0rc2
     cpplint==1.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.11.0rc2
+    tensorflow==2.11.0
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.11.0rc2
+    tensorflow==2.11.0
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.11.0rc2
+    tensorflow==2.11.0
     cpplint==1.5.5


### PR DESCRIPTION
*Description of changes:*

Add support for TensorFlow 2.11.0 and Python 3.10. 

Aside from changing version numbers, definitions from `src/pipemode_op/include/tensorflow/core/lib/hash/crc32c.h` had to be moved to `src/pipemode_op/include/tensorflow/tsl/lib/hash/crc32c.h`, to match the change made in tensorflow/tensorflow [here](src/pipemode_op/include/tensorflow/tsl/lib/hash/crc32c.h).

I also switched `tostring()` to `tobytes()` in `recordio_utils.py` to eliminate deprecation warning.

Passes all tests locally using Python 3.10.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
