### PR TITLE
feature: Add support for TF2.12.0 & deprecate Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,9 +97,9 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
-   * - 2.12.0rc1.1.18.x
+   * - 2.12.0.1.18.x
      - v1.18.x
-     - 2.12.0rc1
+     - 2.12.0
      - 3.8, 3.9, 3.10
    * - 2.11.0.1.17.x
      - v1.17.x

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.7-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.11.0.
+This package supports Python 3.8-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.12.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -97,6 +97,10 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
+   * - 2.12.0.1.18.x
+     - v1.18.x
+     - 2.12.0
+     - 3.8, 3.9, 3.10, 3.11   
    * - 2.11.0.1.17.x
      - v1.17.x
      - 2.11.0

--- a/README.rst
+++ b/README.rst
@@ -97,10 +97,10 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
-   * - 2.12.0.1.18.x
+   * - 2.12.0rc1.1.18.x
      - v1.18.x
-     - 2.12.0
-     - 3.8, 3.9, 3.10, 3.11   
+     - 2.12.0rc1
+     - 3.8, 3.9, 3.10
    * - 2.11.0.1.17.x
      - v1.17.x
      - 2.11.0

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -3,30 +3,30 @@ version: 0.2
 phases:
   build:
     commands:
-      - PACKAGE_FILE_37="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp37-*.whl"
       - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
       - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp310-*.whl"
+      - PACKAGE_FILE_311="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp311-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
       - GPG_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/password --query SecretString --output text)
 
       - echo 'md5sum of python packages:'
-      - md5sum $PACKAGE_FILE_37
       - md5sum $PACKAGE_FILE_38
       - md5sum $PACKAGE_FILE_39
       - md5sum $PACKAGE_FILE_310
+      - md5sum $PACKAGE_FILE_311
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_37
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_38
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_39
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_310
+      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_311
 
       # publish to pypi
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_37 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_311 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -6,7 +6,7 @@ phases:
       - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
       - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp310-*.whl"
-      - PACKAGE_FILE_311="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp311-*.whl"
+      # - PACKAGE_FILE_311="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp311-*.whl"
       - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
       - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
@@ -16,17 +16,17 @@ phases:
       - md5sum $PACKAGE_FILE_38
       - md5sum $PACKAGE_FILE_39
       - md5sum $PACKAGE_FILE_310
-      - md5sum $PACKAGE_FILE_311
+      # - md5sum $PACKAGE_FILE_311
 
       # import private key and ensure passphrase is cached
       - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_38
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_39
       - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_310
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_311
+      # - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_311
 
       # publish to pypi
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 --sign -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 --sign -u $PYPI_USER -p $PYPI_PASSWORD
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_311 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      # - python3 -m twine upload --skip-existing $PACKAGE_FILE_311 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -29,7 +29,7 @@ phases:
         PYTHON_VERSIONS="python3.10 python3.9 python3.8"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.12.0rc1 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.12.0 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -18,15 +18,15 @@ phases:
       - python3.10 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
-      - tox -e py37,py38,py39,py310 -- test/
+      - tox -e py38,py39,py310,py311 -- test/
 
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.10 python3.9 python3.8 python3.7"
+        PYTHON_VERSIONS="python 3.11 python3.10 python3.9 python3.8"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.11.0 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.12.0rc0 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 
@@ -35,9 +35,9 @@ phases:
 
 artifacts:
   files:
-    - dist/sagemaker_tensorflow-*-cp37-*.whl
     - dist/sagemaker_tensorflow-*-cp38-*.whl
     - dist/sagemaker_tensorflow-*-cp39-*.whl
     - dist/sagemaker_tensorflow-*-cp310-*.whl
+    - dist/sagemaker_tensorflow-*-cp311-*.whl
   name: ARTIFACT_1
   discard-paths: yes

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -29,7 +29,7 @@ phases:
         PYTHON_VERSIONS="python3.10 python3.9 python3.8"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.12.0rc0 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.12.0rc1 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -6,6 +6,7 @@ phases:
       - apt-get update
       - apt-get -y install libcurl4-openssl-dev g++-9
       - python3.10 -m pip install cpplint==1.5.5
+      # - python3.11 -m pip install cpplint==1.5.5
       - start-dockerd
 
   build:
@@ -16,14 +17,16 @@ phases:
       - tox -e flake8
 
       - python3.10 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
+      # - python3.11 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
-      - tox -e py38,py39,py310,py311 -- test/
+      - tox -e py38,py39,py310 -- test/
+      # - tox -e py38,py39,py310,py311 -- test/
 
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python 3.11 python3.10 python3.9 python3.8"
+        PYTHON_VERSIONS="python3.10 python3.9 python3.8"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
           $PYTHON -m pip install wheel tensorflow==2.12.0rc0 twine==1.11 cmake
@@ -38,6 +41,6 @@ artifacts:
     - dist/sagemaker_tensorflow-*-cp38-*.whl
     - dist/sagemaker_tensorflow-*-cp39-*.whl
     - dist/sagemaker_tensorflow-*-cp310-*.whl
-    - dist/sagemaker_tensorflow-*-cp311-*.whl
+    # - dist/sagemaker_tensorflow-*-cp311-*.whl
   name: ARTIFACT_1
   discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,4 +13,4 @@ phases:
 
       - python3.10 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py37,py38,py39,py310 -- test/
+      - tox -e py38,py39,py310,py311 -- test/

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,4 +13,5 @@ phases:
 
       - python3.10 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py38,py39,py310,py311 -- test/
+      - tox -e py38,py39,py310 -- test/
+      # - tox -e py38,py39,py310,py311 -- test/

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.12.0rc1"
+TF_VERSION = "2.12.0"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.12.0rc0"
+TF_VERSION = "2.12.0rc1"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.11.0"
+TF_VERSION = "2.12.0rc0"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.11.0.1.17.0',
+    version='2.12.0rc.1.18.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},
@@ -111,17 +111,17 @@ setup(
     license='Apache License 2.0',
     author='Amazon Web Services',
     maintainer='Amazon Web Services',
-    python_requires=">= 3.7",
+    python_requires=">= 3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.12.0.1.18.0',
+    version='2.12.0rc1.1.18.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.12.0rc.1.18.0',
+    version='2.12.0.1.18.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},
@@ -120,8 +120,8 @@ setup(
         "Programming Language :: Python",
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.10'
+        # 'Programming Language :: Python :: 3.11'
     ],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.12.0rc1.1.18.0',
+    version='2.12.0.1.18.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
+++ b/src/pipemode_op/Dataset/src/pipemode_dataset_op_kernel.cpp
@@ -50,6 +50,7 @@ using tensorflow::data::IteratorContext;
 using tensorflow::data::IteratorStateReader;
 using tensorflow::data::IteratorStateWriter;
 using tensorflow::mutex;
+using tensorflow::OkStatus;
 using tensorflow::mutex_lock;
 using tensorflow::Node;
 using tensorflow::OpKernelContext;
@@ -218,7 +219,7 @@ class PipeModeDatasetOp : public DatasetOpKernel {
                 } catch(std::runtime_error& err) {
                     return Status(tensorflow::error::INTERNAL, err.what());
                 }
-                return Status::OK();
+                return OkStatus();;
             }
             ~Iterator() {
                 if (benchmark_) {

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.12.0rc0
+ARG tensorflow_version=2.12.0rc1
 ARG script
 ARG python
 

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.11.0
+ARG tensorflow_version=2.12.0rc0
 ARG script
 ARG python
 

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.12.0rc1
+ARG tensorflow_version=2.12.0
 ARG script
 ARG python
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.12.0rc1
+    tensorflow==2.12.0
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.12.0rc1
+    tensorflow==2.12.0
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.12.0rc1
+    tensorflow==2.12.0
     cpplint==1.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,flake8,cpplint
+envlist = py38,py39,py310,py311,flake8,cpplint
 
 skip_missing_interpreters = False
 
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.11.0
+    tensorflow==2.12.0rc0
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.11.0
+    tensorflow==2.12.0rc0
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.11.0
+    tensorflow==2.12.0rc0
     cpplint==1.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,flake8,cpplint
+envlist = py38,py39,py310,flake8,cpplint
 
 skip_missing_interpreters = False
 
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.12.0rc0
+    tensorflow==2.12.0rc1
     awslogs==0.14.0
     docker==5.0.2
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.12.0rc0
+    tensorflow==2.12.0rc1
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.12.0rc0
+    tensorflow==2.12.0rc1
     cpplint==1.5.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade sagemaker-tensorflow-extensions to support new tensorflow-extensions v2.12.0rc0 & Python 3.11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
