### PR TITLE
Remove name from element spec of PipeMode

### DIFF
--- a/src/sagemaker_tensorflow/pipemode.py
+++ b/src/sagemaker_tensorflow/pipemode.py
@@ -119,5 +119,4 @@ class PipeModeDataset(dataset_ops.Dataset):
         return tensor_spec.TensorSpec(
             shape=self.output_shapes,
             dtype=self.output_types,
-            name=self.channel,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     contextlib2==21.6.0
     tensorflow==2.13.0
     awslogs==0.14.0
-    docker==5.0.2
+    docker==6.1.0
     cmake==3.21.2
 
 [testenv:flake8]


### PR DESCRIPTION
*Issue #, if available:*

* N/A

*Description of changes:*

Remove `name` property in element_spec of `PipeMode`. With this property, `tensorflow.data.Dataset.sample_from_datasets` is failing after a change (https://github.com/tensorflow/tensorflow/commit/de10bca1e8c6b916eafc00ef7c83eb6e3638ab39) in Tensorflow 2.9. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
