### PR TITLE
change: Switch to using GitHub API Token for AuthN

### DIFF
--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -7,26 +7,17 @@ phases:
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
       - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp310-*.whl"
       # - PACKAGE_FILE_311="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp311-*.whl"
-      - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
-      - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
-      - GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/private_key --query SecretString --output text)
-      - GPG_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/gpg/password --query SecretString --output text)
-
+      - PYPI_USER=__token__
+      - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/sagemaker-python-sdk-token --query SecretString --output text)
+      
       - echo 'md5sum of python packages:'
       - md5sum $PACKAGE_FILE_38
       - md5sum $PACKAGE_FILE_39
       - md5sum $PACKAGE_FILE_310
       # - md5sum $PACKAGE_FILE_311
 
-      # import private key and ensure passphrase is cached
-      - echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_38
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_39
-      - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_310
-      # - gpg --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --detach-sign -a -o /dev/null $PACKAGE_FILE_311
-
       # publish to pypi
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 --sign -u $PYPI_USER -p $PYPI_PASSWORD
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 --sign -u $PYPI_USER -p $PYPI_PASSWORD
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 --sign -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 -u $PYPI_USER -p $PYPI_PASSWORD
+      - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 -u $PYPI_USER -p $PYPI_PASSWORD
       # - python3 -m twine upload --skip-existing $PACKAGE_FILE_311 --sign -u $PYPI_USER -p $PYPI_PASSWORD


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unblock PyPI release by switching to GitHub API Token for AuthN


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
