### PR TITLE
feat: Support TensorFlow v2.14.0 and remove Py38

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.8-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.13.0.
+This package supports Python 3.8-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.14.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -97,6 +97,10 @@ Please refer to below table for release support information:
      - Sagemaker TensorFlow Extensions Release Version
      - TensorFlow Release Version
      - Sagemaker TensorFlow Extentions Supported Python Versions
+   * - 2.14.0.1.20.x
+     - v1.20.x
+     - 2.14.0
+     - 3.8, 3.9, 3.10
    * - 2.13.0.1.19.x
      - v1.19.x
      - 2.13.0

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SageMaker TensorFlow
 
 This package contains SageMaker-specific extensions to TensorFlow, including the :python:`PipeModeDataset` class, that allows SageMaker Pipe Mode channels to be read using TensorFlow Datasets.
 
-This package supports Python 3.8-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.14.0.
+This package supports Python 3.9-3.10 and TensorFlow versions 1.7 and higher, including 2.0-2.14.0.
 For TensorFlow 1.x support, see the `master branch <https://github.com/aws/sagemaker-tensorflow-extensions>`_.
 ``sagemaker-tensorflow`` releases for all supported versions are available on `PyPI <https://pypi.org/project/sagemaker-tensorflow/#history>`_.
 
@@ -100,7 +100,7 @@ Please refer to below table for release support information:
    * - 2.14.0.1.20.x
      - v1.20.x
      - 2.14.0
-     - 3.8, 3.9, 3.10
+     - 3.9, 3.10
    * - 2.13.0.1.19.x
      - v1.19.x
      - 2.13.0

--- a/buildspec-deploy.yml
+++ b/buildspec-deploy.yml
@@ -3,7 +3,6 @@ version: 0.2
 phases:
   build:
     commands:
-      - PACKAGE_FILE_38="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp38-*.whl"
       - PACKAGE_FILE_39="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp39-*.whl"
       - PACKAGE_FILE_310="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp310-*.whl"
       # - PACKAGE_FILE_311="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker_tensorflow-*-cp311-*.whl"
@@ -11,13 +10,11 @@ phases:
       - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/sagemaker-python-sdk-token --query SecretString --output text)
       
       - echo 'md5sum of python packages:'
-      - md5sum $PACKAGE_FILE_38
       - md5sum $PACKAGE_FILE_39
       - md5sum $PACKAGE_FILE_310
       # - md5sum $PACKAGE_FILE_311
 
       # publish to pypi
-      - python3 -m twine upload --skip-existing $PACKAGE_FILE_38 -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_39 -u $PYPI_USER -p $PYPI_PASSWORD
       - python3 -m twine upload --skip-existing $PACKAGE_FILE_310 -u $PYPI_USER -p $PYPI_PASSWORD
       # - python3 -m twine upload --skip-existing $PACKAGE_FILE_311 --sign -u $PYPI_USER -p $PYPI_PASSWORD

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -20,13 +20,13 @@ phases:
       # - python3.11 -m cpplint --linelength=120 --filter=-build/c++11,-build/header_guard --extensions=cpp,hpp --quiet --recursive src/
 
       # run tests
-      - tox -e py38,py39,py310 -- test/
+      - tox -e py39,py310 -- test/
       # - tox -e py38,py39,py310,py311 -- test/
 
       # generate the distribution package
       - python setup.py sdist
       - |
-        PYTHON_VERSIONS="python3.10 python3.9 python3.8"
+        PYTHON_VERSIONS="python3.10 python3.9"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
           $PYTHON -m pip install wheel tensorflow==2.14.0 twine==1.11 cmake
@@ -38,7 +38,6 @@ phases:
 
 artifacts:
   files:
-    - dist/sagemaker_tensorflow-*-cp38-*.whl
     - dist/sagemaker_tensorflow-*-cp39-*.whl
     - dist/sagemaker_tensorflow-*-cp310-*.whl
     # - dist/sagemaker_tensorflow-*-cp311-*.whl

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -29,7 +29,7 @@ phases:
         PYTHON_VERSIONS="python3.10 python3.9 python3.8"
         for PYTHON in ${PYTHON_VERSIONS}; do
           $PYTHON -m pip install -U pip
-          $PYTHON -m pip install wheel tensorflow==2.13.0 twine==1.11 cmake
+          $PYTHON -m pip install wheel tensorflow==2.14.0 twine==1.11 cmake
           $PYTHON setup.py build bdist_wheel --plat-name manylinux1_x86_64
         done;
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,5 +13,5 @@ phases:
 
       - python3.10 -m cpplint --linelength=120 --filter=-build/c++11 --extensions=cpp,hpp --quiet --recursive src/
 
-      - tox -e py38,py39,py310 -- test/
+      - tox -e py39,py310 -- test/
       # - tox -e py38,py39,py310,py311 -- test/

--- a/create_integ_test_docker_images.py
+++ b/create_integ_test_docker_images.py
@@ -9,7 +9,7 @@ import botocore
 import glob
 import sys
 
-TF_VERSION = "2.13.0"
+TF_VERSION = "2.14.0"
 REGION = "us-west-2"
 REPOSITORY_NAME = "sagemaker-tensorflow-extensions-test"
 

--- a/setup.py
+++ b/setup.py
@@ -111,14 +111,13 @@ setup(
     license='Apache License 2.0',
     author='Amazon Web Services',
     maintainer='Amazon Web Services',
-    python_requires=">= 3.8",
+    python_requires=">= 3.9",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10'
         # 'Programming Language :: Python :: 3.11'

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='sagemaker_tensorflow',
-    version='2.13.0.1.19.1',
+    version='2.14.0.1.20.0',
     description='Amazon Sagemaker specific TensorFlow extensions.',
     packages=find_packages(where='src', exclude=('test',)),
     package_dir={'': 'src'},

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 ARG device=cpu
-ARG tensorflow_version=2.13.0
+ARG tensorflow_version=2.14.0
 ARG script
 ARG python
 

--- a/test/integ/Dockerfile
+++ b/test/integ/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:20.04
+FROM public.ecr.aws/lts/ubuntu:22.04
 
 ARG device=cpu
 ARG tensorflow_version=2.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     pytest-xdist==2.3.0
     mock==4.0.3
     contextlib2==21.6.0
-    tensorflow==2.13.0
+    tensorflow==2.14.0
     awslogs==0.14.0
     docker==6.1.0
     cmake==3.21.2
@@ -61,7 +61,7 @@ deps =
     cmake==3.21.2
     flake8==3.9.2
     flake8-future-import==0.4.6
-    tensorflow==2.13.0
+    tensorflow==2.14.0
 
 commands = flake8
 
@@ -71,5 +71,5 @@ commands =
 
 deps =
     cmake==3.21.2
-    tensorflow==2.13.0
+    tensorflow==2.14.0
     cpplint==1.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,flake8,cpplint
+envlist = py39,py310,flake8,cpplint
 
 skip_missing_interpreters = False
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 * Changes to support the TensorFlow `v2.14.0`
 * Release notes TF2.14: https://github.com/tensorflow/tensorflow/releases/tag/v2.14.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
